### PR TITLE
Replace all occurrences of unused data variables with _ to bypass warnings

### DIFF
--- a/spec/executor_spec.rb
+++ b/spec/executor_spec.rb
@@ -87,7 +87,7 @@ describe FuzzBert::Executor do
           data("1") { -> { "a" } }
         end
       end
-      let (:handler) { TestHandler.new { |data| raise RuntimeError.new } }
+      let (:handler) { TestHandler.new { |_| raise RuntimeError.new } }
       it { -> { subject }.should_not raise_error }
     end
 
@@ -95,22 +95,22 @@ describe FuzzBert::Executor do
       called = false
       let (:suite) do
         FuzzBert::TestSuite.create("suite") do
-          deploy { |data| raise "boo!" }
+          deploy { |_| raise "boo!" }
           data("1") { -> { "a" } }
         end
       end
-      let (:handler) { TestHandler.new { |data| called = true } }
+      let (:handler) { TestHandler.new { |_| called = true } }
       it { -> { subject }.should_not raise_error; called.should be_true }
     end
 
     context "allows rescued exceptions" do
       let (:suite) do
         FuzzBert::TestSuite.create("suite") do
-          deploy { |data| begin; raise "boo!"; rescue RuntimeError; end }
+          deploy { |_| begin; raise "boo!"; rescue RuntimeError; end }
           data("1") { -> { "a" } }
         end
       end
-      let (:handler) { TestHandler.new { |data| raise RuntimeError.new } }
+      let (:handler) { TestHandler.new { |_| raise RuntimeError.new } }
       it { -> { subject }.should_not raise_error }
     end
 
@@ -118,11 +118,11 @@ describe FuzzBert::Executor do
       called = false
       let (:suite) do
         FuzzBert::TestSuite.create("suite") do
-          deploy { |data| Process.kill(:SEGV, Process.pid) }
+          deploy { |_| Process.kill(:SEGV, Process.pid) }
           data("1") { -> { "a" } }
         end
       end
-      let (:handler) { TestHandler.new { |data| called = true } }
+      let (:handler) { TestHandler.new { |_| called = true } }
       let (:generator) { FuzzBert::Generator.new("test") { "a" } }
       it { -> { subject }.should_not raise_error; called.should be_true }
     end if false #don't want to SEGV every time

--- a/spec/fuzz/fuzz_custom_handler.rb
+++ b/spec/fuzz/fuzz_custom_handler.rb
@@ -15,6 +15,6 @@ module FuzzBert::Spec
 end
 
 fuzz "failing" do
-  deploy { |data| raise "boo!" }
+  deploy { |_| raise "boo!" }
   data("some") { -> {"a"} }
 end

--- a/spec/fuzz/fuzz_nothing.rb
+++ b/spec/fuzz/fuzz_nothing.rb
@@ -1,6 +1,6 @@
 require 'fuzzbert'
 
 fuzz "nothing" do
-  deploy { |data| }
+  deploy { |_| }
   data("some") { -> {"a"} }
 end


### PR DESCRIPTION
Replace all occurrences of unused data variables with _ to bypass unused  variables warning
