### PR TITLE
fixed a call to Base64.encode to be Base64.encode64 in the random_b64_fixlen generator

### DIFF
--- a/lib/fuzzbert/generators.rb
+++ b/lib/fuzzbert/generators.rb
@@ -3,7 +3,7 @@ require 'base64'
 module FuzzBert::Generators
 
   module_function
-    
+
   def random(limit=1024)
     -> { random_bytes(limit) { |data| data } }
   end
@@ -21,7 +21,7 @@ module FuzzBert::Generators
   end
 
   def random_b64_fixlen(len)
-    -> { random_bytes_fixlen(b64_len(len)) { |data| Base64.encode(data) } }
+    -> { random_bytes_fixlen(b64_len(len)) { |data| Base64.encode64(data) } }
   end
 
   def random_hex_fixlen(len)
@@ -37,7 +37,7 @@ module FuzzBert::Generators
       ret
     end
   end
-  
+
   def fixed(data)
     -> { data }
   end


### PR DESCRIPTION
This is my first commit to this project (or any opensource project that I don't actually own) and I didn't see any Contribution readme so please let me know if I need to change anything. 